### PR TITLE
Allow config override via settings.py

### DIFF
--- a/python2/raygun4py/middleware/django.py
+++ b/python2/raygun4py/middleware/django.py
@@ -1,19 +1,14 @@
 from __future__ import absolute_import
 
-import copy
-
 from django.conf import settings
 
 from raygun4py import raygunprovider
 
-DEFAULT_CONFIG = {}
-
 class Provider(object):
 
     def __init__(self):
-    	apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', None)
-    	config = copy.deepcopy(DEFAULT_CONFIG)
-    	config.update(getattr(settings, 'RAYGUN4PY_CONFIG', {}))
+    	config = getattr(settings, 'RAYGUN4PY_CONFIG', {})
+    	apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', config.get('api_key', None))
     	
         self.sender = raygunprovider.RaygunSender(apiKey, config=config)
 

--- a/python2/raygun4py/middleware/django.py
+++ b/python2/raygun4py/middleware/django.py
@@ -1,14 +1,21 @@
 from __future__ import absolute_import
 
+import copy
+
 from django.conf import settings
 
 from raygun4py import raygunprovider
+
+DEFAULT_CONFIG = {}
 
 class Provider(object):
 
     def __init__(self):
     	apiKey = getattr(settings, 'RAYGUN4PY_API_KEY', None)
-        self.sender = raygunprovider.RaygunSender(apiKey)
+    	config = copy.deepcopy(DEFAULT_CONFIG)
+    	config.update(getattr(settings, 'RAYGUN4PY_CONFIG', {}))
+    	
+        self.sender = raygunprovider.RaygunSender(apiKey, config=config)
 
     def process_exception(self, request, exception):
     	raygunRequest = self._mapRequest(request)

--- a/python2/raygun4py/raygunprovider.py
+++ b/python2/raygun4py/raygunprovider.py
@@ -20,17 +20,6 @@ DEFAULT_CONFIG = {
     'user': None,
 }
 
-def camel(k):
-    "Turns snake_case_strings into camelCaseStrings."
-    if k.lower() != k:
-        return k  # Don't transform camelCase value, it's good to go.
-    new_key = k.replace('_', ' ').title().replace(' ', '')
-    return new_key[0].lower() + new_key[1:]
-
-def normalize_dict(d):
-    return dict([
-        (camel(k), v) for k, v in d.items()
-    ])
 
 class RaygunSender:
 
@@ -51,8 +40,8 @@ class RaygunSender:
                                   "compile the socket module with SSL support.")
         
         # Set up the default values
-        default_config = normalize_dict(copy.deepcopy(DEFAULT_CONFIG))
-        default_config.update(normalize_dict(config or {}))
+        default_config = utilities.camelize_dict(copy.deepcopy(DEFAULT_CONFIG))
+        default_config.update(utilities.camelize_dict(config or {}))
         for k, v in default_config.items():
             setattr(self, k, v)
 

--- a/python2/raygun4py/raygunprovider.py
+++ b/python2/raygun4py/raygunprovider.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import copy
 import socket
 import logging
 import jsonpickle
@@ -8,13 +9,36 @@ from raygun4py import raygunmsgs
 from raygun4py import utilities
 
 
+DEFAULT_CONFIG = {
+    'before_send_callback': None,
+    'filtered_keys': [],
+    'ignored_exceptions': [],
+    'proxy': None,
+    'transmit_global_variables': True,
+    'transmit_local_variables': True,
+    'userversion': "Not defined",
+    'user': None,
+}
+
+def camel(k):
+    "Turns snake_case_strings into camelCaseStrings."
+    if k.lower() != k:
+        return k  # Don't transform camelCase value, it's good to go.
+    new_key = k.replace('_', ' ').title().replace(' ', '')
+    return new_key[0].lower() + new_key[1:]
+
+def normalize_dict(d):
+    return dict([
+        (camel(k), v) for k, v in d.items()
+    ])
+
 class RaygunSender:
 
     apiKey = None
     endpointhost = 'api.raygun.io'
     endpointpath = '/entries'
 
-    def __init__(self, apiKey, config={}):
+    def __init__(self, apiKey, config=None):
         if (apiKey):
             self.apiKey = apiKey
         else:
@@ -25,14 +49,12 @@ class RaygunSender:
         except ImportError:
             print >> sys.stderr, ("RaygunProvider error: No SSL support available, cannot send. Please"
                                   "compile the socket module with SSL support.")
-        self.userversion = "Not defined"
-        self.user = None
-        self.ignoredExceptions = []
-        self.filteredKeys = []
-        self.proxy = None
-        self.beforeSendCallback = None
-        self.transmitLocalVariables = config['transmitLocalVariables'] if 'transmitLocalVariables' in config else True
-        self.transmitGlobalVariables = config['transmitGlobalVariables'] if 'transmitGlobalVariables' in config else True
+        
+        # Set up the default values
+        default_config = normalize_dict(copy.deepcopy(DEFAULT_CONFIG))
+        default_config.update(normalize_dict(config or {}))
+        for k, v in default_config.items():
+            setattr(self, k, v)
 
     def set_version(self, version):
         if isinstance(version, basestring):

--- a/python2/raygun4py/utilities.py
+++ b/python2/raygun4py/utilities.py
@@ -31,6 +31,7 @@ def camel(k):
     new_key = k.replace('_', ' ').title().replace(' ', '')
     return new_key[0].lower() + new_key[1:]
 
+
 def camelize_dict(d):
     return dict([
         (camel(k), v) for k, v in d.items()

--- a/python2/raygun4py/utilities.py
+++ b/python2/raygun4py/utilities.py
@@ -23,3 +23,15 @@ def filter_keys(filteredKeys, object):
             iterationTarget[key] = filter_keys(filteredKeys, iterationTarget[key])
 
     return iterationTarget
+
+def camel(k):
+    "Turns snake_case_strings into camelCaseStrings."
+    if k.lower() != k:
+        return k  # Don't transform camelCase value, it's good to go.
+    new_key = k.replace('_', ' ').title().replace(' ', '')
+    return new_key[0].lower() + new_key[1:]
+
+def camelize_dict(d):
+    return dict([
+        (camel(k), v) for k, v in d.items()
+    ])

--- a/python2/raygun4py/utilities.py
+++ b/python2/raygun4py/utilities.py
@@ -24,6 +24,7 @@ def filter_keys(filteredKeys, object):
 
     return iterationTarget
 
+
 def camel(k):
     "Turns snake_case_strings into camelCaseStrings."
     if k.lower() != k:


### PR DESCRIPTION
This change adds the ability for users of the Django web framework to specify some raygun4py settings via a more-conventional settings.py mechanism.
